### PR TITLE
set up idranges #4

### DIFF
--- a/src/ontology/mhpo-idranges.owl
+++ b/src/ontology/mhpo-idranges.owl
@@ -16,8 +16,8 @@ Ontology: <http://purl.obolibrary.org/obo/mhpo/mhpo-idranges.owl>
 
 Annotations: 
     idsfor: "MHPO",
-    idprefix: "http://purl.obolibrary.org/obo/MHPO_",
-    iddigits: 7
+    idprefix: "https://purl.org/mhpo/ontology/MHPO_",
+    iddigits: 8
 
 AnnotationProperty: idprefix:
 
@@ -33,19 +33,28 @@ AnnotationProperty: allocatedto:
 Datatype: idrange:1
 
     Annotations: 
-        allocatedto: "ONTOLOGY-CREATOR"
+        allocatedto: "Mirjam Stappel"
     
     EquivalentTo: 
-        xsd:integer[>= 0 , <= 999999]
+        xsd:integer[>= 20000 , <= 29999]
 
     
 Datatype: idrange:2
 
     Annotations: 
-        allocatedto: "ADDITIONAL EDITOR"
+        allocatedto: "Ludwig Huelk"
     
     EquivalentTo: 
-        xsd:integer[>= 1000000 , <= 1999999]
+        xsd:integer[>= 10000 , <= 19999]
+		
+
+Datatype: idrange:3
+
+    Annotations: 
+        allocatedto: "Norman Zielke"
+    
+    EquivalentTo: 
+        xsd:integer[>= 30000 , <= 39999]
     
     
 Datatype: xsd:integer


### PR DESCRIPTION
## Summary of the discussion

I added @Ludee, @NormanZielke and myself to the idranges file. If you pull this branch and open protege, you should be asked which id you want to use. Please check also the preference, the "new entities" section should look like this (@Ludee 10000-19999 and @NormanZielke 30000-39999).
<img width="861" height="1225" alt="grafik" src="https://github.com/user-attachments/assets/c7a2a471-a7f9-45ac-a44e-3964a1bf8553" />


## Type of change (CHANGELOG.md)

### Changed

- mhpo-idranges.owl

## Workflow checklist

### Automation

Part of # / Closes #4

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/develop/CHANGELOG.md)
- [ ] 📙 Update the documentation
- [ ] 🐙 Assign a reviewer to the PR

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
