### PR TITLE
add `municipal heap plan` and fix some annotation properties

### DIFF
--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -6,7 +6,9 @@ Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
 Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 Prefix(dcterms:=<http://purl.org/dc/terms/>)
-
+Prefix(oeo:=<https://openenergyplatform.org/ontology/oeo/>)
+Prefix(iao:=<<http://purl.obolibrary.org/obo/iao.owl#>)
+Prefix(bfo:=<http://purl.obolibrary.org/obo/bfo.owl#>)
 
 Ontology(<http://purl.obolibrary.org/obo/mhpo.owl>
 Import(<http://purl.obolibrary.org/obo/mhpo/imports/bfo_import.owl>)
@@ -31,6 +33,7 @@ Declaration(AnnotationProperty(dcterms:license))
 Declaration(AnnotationProperty(dcterms:title))
 Declaration(AnnotationProperty(rdfs:comment))
 Declaration(AnnotationProperty(owl:versionInfo))
+Declaration(AnnotationProperty(iao:0000118))
 ############################
 #   Annotation Properties
 ############################
@@ -59,7 +62,9 @@ AnnotationAssertion(rdfs:label rdfs:comment "comment")
 
 AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 
+# Annotation Property: iao:0000118 (alternative term)
 
+AnnotationAssertion(rdfs:label iao:0000118 "alternative term")
 
 ############################
 #   Classes

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -25,7 +25,7 @@ Annotation(owl:versionInfo "to be added after first release")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/MHPO_0000000>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00020003>))
-Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
+Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/iao_0000118>))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
@@ -36,9 +36,9 @@ Declaration(AnnotationProperty(owl:versionInfo))
 #   Annotation Properties
 ############################
 
-# Annotation Property: <http://purl.obolibrary.org/obo/mhpo.owl#<http://purl.obolibrary.org/obo/iao.owl#0000118> (alternative term)
+# Annotation Property: <http://purl.obolibrary.org/obo/iao_0000118> (alternative label)
 
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/mhpo.owl#<http://purl.obolibrary.org/obo/iao.owl#0000118> "alternative term")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/iao_0000118> "alternative label")
 
 # Annotation Property: dcterms:creator (creator)
 
@@ -77,9 +77,9 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MHPO_0000000> "ro
 # Class: <https://purl.org/mhpo/ontology/MHPO_00020003> (municipal heat plan)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00020003> "A municipal heat plan is a plan specification that contains a heating plan in accordance with §23 of the German Heating Planning Act (WPG). It includes a cartographic representation of the current status and potential analysis, the division into heat supply zones, the indicators of the target scenario, the presentation of heat supply types for the target year, and measures of the implementation strategy. The textual and graphical explanations of the suitability assessment, the current status analysis, the target scenario, and the implementation strategy may be attached to the heat plan as external references."@en)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "WP_Plan"@de)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "Kommunale Wärmeplanung"@de)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "KWP"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/iao_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "KWP"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/iao_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "Kommunale Wärmeplanung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/iao_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "WP_Plan"@de)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00020003> "municipal heat plan"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> <http://purl.obolibrary.org/obo/IAO_0000104>)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -6,9 +6,7 @@ Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
 Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 Prefix(dcterms:=<http://purl.org/dc/terms/>)
-Prefix(oeo:=<https://openenergyplatform.org/ontology/oeo/>)
-Prefix(iao:=<<http://purl.obolibrary.org/obo/iao.owl#>)
-Prefix(bfo:=<http://purl.obolibrary.org/obo/bfo.owl#>)
+
 
 Ontology(<http://purl.obolibrary.org/obo/mhpo.owl>
 Import(<http://purl.obolibrary.org/obo/mhpo/imports/bfo_import.owl>)
@@ -27,16 +25,20 @@ Annotation(owl:versionInfo "to be added after first release")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/MHPO_0000000>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00020003>))
+Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
 Declaration(AnnotationProperty(dcterms:title))
 Declaration(AnnotationProperty(rdfs:comment))
 Declaration(AnnotationProperty(owl:versionInfo))
-Declaration(AnnotationProperty(iao:0000118))
 ############################
 #   Annotation Properties
 ############################
+
+# Annotation Property: <http://purl.obolibrary.org/obo/mhpo.owl#<http://purl.obolibrary.org/obo/iao.owl#0000118> (alternative term)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/mhpo.owl#<http://purl.obolibrary.org/obo/iao.owl#0000118> "alternative term")
 
 # Annotation Property: dcterms:creator (creator)
 
@@ -62,9 +64,7 @@ AnnotationAssertion(rdfs:label rdfs:comment "comment")
 
 AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 
-# Annotation Property: iao:0000118 (alternative term)
 
-AnnotationAssertion(rdfs:label iao:0000118 "alternative term")
 
 ############################
 #   Classes
@@ -77,7 +77,10 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MHPO_0000000> "ro
 # Class: <https://purl.org/mhpo/ontology/MHPO_00020003> (municipal heat plan)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00020003> "A municipal heat plan is a plan specification that contains a heating plan in accordance with §23 of the German Heating Planning Act (WPG). It includes a cartographic representation of the current status and potential analysis, the division into heat supply zones, the indicators of the target scenario, the presentation of heat supply types for the target year, and measures of the implementation strategy. The textual and graphical explanations of the suitability assessment, the current status analysis, the target scenario, and the implementation strategy may be attached to the heat plan as external references."@en)
-AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00020003> "municipal heat plan"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "WP_Plan"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "Kommunale Wärmeplanung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "KWP"@de)
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00020003> "municipal heat plan"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> <http://purl.obolibrary.org/obo/IAO_0000104>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -19,17 +19,18 @@ The aim is to reduce greenhouse gas emissions and heat consumption, increase the
 Annotation(dcterms:license <http://creativecommons.org/publicdomain/zero/1.0/>)
 Annotation(dcterms:license <https://opensource.org/license/mit>)
 Annotation(dcterms:title "Municipal Heat Planning Ontology")
-Annotation(owl:versionInfo "to be added after first release")
-Annotation(rdfs:comment "External documentation see <https://openenergyplatform.github.io/municipal-heat-planning-ontology> or <https://purl.org/mhpo>")
 Annotation(rdfs:comment "Contact <mirjam.stappel@uos.de> or <Ludwig.Huelk@rl-institut.de>")
+Annotation(rdfs:comment "External documentation see <https://openenergyplatform.github.io/municipal-heat-planning-ontology> or <https://purl.org/mhpo>")
+Annotation(owl:versionInfo "to be added after first release")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/MHPO_0000000>))
+Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00020003>))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
 Declaration(AnnotationProperty(dcterms:title))
-Declaration(AnnotationProperty(owl:versionInfo))
 Declaration(AnnotationProperty(rdfs:comment))
+Declaration(AnnotationProperty(owl:versionInfo))
 ############################
 #   Annotation Properties
 ############################
@@ -50,13 +51,13 @@ AnnotationAssertion(rdfs:label dcterms:license "license")
 
 AnnotationAssertion(rdfs:label dcterms:title "title")
 
-# Annotation Property: owl:versionInfo (versionInfo)
-
-AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
-
 # Annotation Property: rdfs:comment (comment)
 
 AnnotationAssertion(rdfs:label rdfs:comment "comment")
+
+# Annotation Property: owl:versionInfo (versionInfo)
+
+AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 
 
 
@@ -67,6 +68,12 @@ AnnotationAssertion(rdfs:label rdfs:comment "comment")
 # Class: <http://purl.obolibrary.org/obo/MHPO_0000000> (root node)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MHPO_0000000> "root node"@en)
+
+# Class: <https://purl.org/mhpo/ontology/MHPO_00020003> (municipal heat plan)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00020003> "A municipal heat plan is a plan specification that contains a heating plan in accordance with §23 of the German Heating Planning Act (WPG). It includes a cartographic representation of the current status and potential analysis, the division into heat supply zones, the indicators of the target scenario, the presentation of heat supply types for the target year, and measures of the implementation strategy. The textual and graphical explanations of the suitability assessment, the current status analysis, the target scenario, and the implementation strategy may be attached to the heat plan as external references."@en)
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00020003> "municipal heat plan"@de)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> <http://purl.obolibrary.org/obo/IAO_0000104>)
 
 
 )

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -25,7 +25,8 @@ Annotation(owl:versionInfo "to be added after first release")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/MHPO_0000000>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00020003>))
-Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/iao_0000118>))
+Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
+Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(dcterms:creator))
 Declaration(AnnotationProperty(dcterms:description))
 Declaration(AnnotationProperty(dcterms:license))
@@ -36,9 +37,9 @@ Declaration(AnnotationProperty(owl:versionInfo))
 #   Annotation Properties
 ############################
 
-# Annotation Property: <http://purl.obolibrary.org/obo/iao_0000118> (alternative label)
+# Annotation Property: <http://purl.obolibrary.org/obo/IAO_0000118> (alternative label)
 
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/iao_0000118> "alternative label")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000118> "alternative label")
 
 # Annotation Property: dcterms:creator (creator)
 
@@ -64,7 +65,9 @@ AnnotationAssertion(rdfs:label rdfs:comment "comment")
 
 AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 
+# Annotation Property: <http://purl.obolibrary.org/obo/IAO_0000115> (definition)
 
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000115> "definition")
 
 ############################
 #   Classes
@@ -77,9 +80,9 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MHPO_0000000> "ro
 # Class: <https://purl.org/mhpo/ontology/MHPO_00020003> (municipal heat plan)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00020003> "A municipal heat plan is a plan specification that contains a heating plan in accordance with §23 of the German Heating Planning Act (WPG). It includes a cartographic representation of the current status and potential analysis, the division into heat supply zones, the indicators of the target scenario, the presentation of heat supply types for the target year, and measures of the implementation strategy. The textual and graphical explanations of the suitability assessment, the current status analysis, the target scenario, and the implementation strategy may be attached to the heat plan as external references."@en)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/iao_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "KWP"@de)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/iao_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "Kommunale Wärmeplanung"@de)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/iao_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "WP_Plan"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "KWP"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "Kommunale Wärmeplanung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00020003> "WP_Plan"@de)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00020003> "municipal heat plan"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> <http://purl.obolibrary.org/obo/IAO_0000104>)
 


### PR DESCRIPTION
## Summary of the discussion

- add `municipal heat plan` based on the proposal in #9
- fix annotation properties from IAO

## Type of change (CHANGELOG.md)

### Added

- municipal heat plan

## Workflow checklist

### Automation

Part of # / Closes #

### PR-Assignee

- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/develop/CHANGELOG.md)
- [ ] 📙 Update the documentation
- [ ] 🐙 Assign a reviewer to the PR

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
