### PR TITLE
add `suitability assessment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- initial suitability assessment, shortened heat planning (#21)
 - municipal heat plan, aggregated inventory analysis, aggregated potential analysis, target scenario, implementation measure, implementation strategy (#9)
 - municipality area, heat supply area, area for decentralized heat supply, unallocated heat supply subarea, and respective roles (#15)
 - district heating area and subclasses, energy saving area, hydrogen grid area, area under suitability assessment, and respective roles (#15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- initial suitability assessment, shortened heat planning (#21)
+- initial suitability assessment, shortened heat planning, has represented heat supply area (#17)
 - municipal heat plan, aggregated inventory analysis, aggregated potential analysis, target scenario, implementation measure, implementation strategy (#9)
 - municipality area, heat supply area, area for decentralized heat supply, unallocated heat supply subarea, and respective roles (#15)
 - district heating area and subclasses, energy saving area, hydrogen grid area, area under suitability assessment, and respective roles (#15)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -515,7 +515,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncor
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
 
-AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@de)
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -127,6 +127,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00020007>))
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00020008>))
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00030001>))
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00030017>))
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00020005> (aggregated inventory analysis)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -506,6 +506,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030017> "Section 14  of the German Heat Planning Act (WPG)")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -124,7 +124,7 @@ AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 AnnotationAssertion(<https://www.commoncoreontologies.org/ont00001754> <https://purl.org/mhpo/ontology/MHPO_00030019> "Section 14  of the German Heat Planning Act (WPG)")
 SubObjectPropertyOf(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://openenergyplatform.org/ontology/oeo/OEO_00010378>)
-ObjectPropertyDomain(<https://purl.org/mhpo/ontology/MHPO_00030019> <http://purl.obolibrary.org/obo/IAO_0000030>)
+ObjectPropertyDomain(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://purl.org/mhpo/ontology/MHPO_00020003>)
 ObjectPropertyRange(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://purl.org/mhpo/ontology/MHPO_00020021>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -519,7 +519,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030018> "A shortened heat planning is a descriptive information content entity that documents, in a municipal heat plan, that one or more heat plan subareas are represented as prospective decentralized heat supply areas based on a suitability assessment indicating that they are highly likely not suitable for supply by a district heating network or a hydrogen grid. Only potentials relevant for decentralized heat supply are considered for these subareas.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030018> "A shortened heat planning is a descriptive information content entity that documents, in a municipal heat plan, that one or more heat plan subareas are represented as prospective decentralized heat supply areas based on a suitability assessment indicating that they are highly likely not suitable for supply by a district heating network or a hydrogen grid. Only potentials relevant for decentralized heat supply are considered for these subareas."@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "Dokumentation der verkürzten Wärmeplanung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning documentation"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "verkürzte Wärmeplanung"@de)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -507,7 +507,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (suitability assessment)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents the initial research of grid bound heat supply, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030017> "Section 14  of the German Heat Planning Act (WPG)")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -515,6 +515,7 @@ AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "i
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030017> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001808> <https://purl.org/mhpo/ontology/MHPO_00020019>))
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -505,12 +505,12 @@ pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-onto
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> <https://purl.org/mhpo/ontology/MHPO_00020019>)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <https://purl.org/mhpo/ontology/MHPO_00020014>))
 
-# Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (suitability assessment)
+# Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (initial suitability assessment)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents the initial research of grid bound heat supply, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030017> "Section 14  of the German Heat Planning Act (WPG)")
-AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "initial suitability assessment"@en)
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030017> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -119,7 +119,7 @@ AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 # Object Property: <https://purl.org/mhpo/ontology/MHPO_00030019> (has represented heat supply area)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030019> "An is-about-relation between an information content entity of a municipal heat plan and a heat supply area to indicate a heat supply area represented in the municipal heat plan."@en)
-AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030019> "has represented heat supply area"@en)
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030019> "represents heat supply area"@en)
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030019> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 AnnotationAssertion(<https://www.commoncoreontologies.org/ont00001754> <https://purl.org/mhpo/ontology/MHPO_00030019> "Section 14  of the German Heat Planning Act (WPG)")

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -520,6 +520,8 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.o
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "verkürzte Wärmeplanung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030018> "Section 14  of the German Heat Planning Act (WPG)")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@en)
+AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030018> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
+pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -59,6 +59,7 @@ Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030013>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030014>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030016>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030017>))
+Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030018>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
@@ -511,6 +512,11 @@ AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "s
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030017> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
+
+# Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
+
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@de)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)
 
 
 DisjointClasses(<https://purl.org/mhpo/ontology/MHPO_00020023> <https://purl.org/mhpo/ontology/MHPO_00020024> <https://purl.org/mhpo/ontology/MHPO_00020025>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -508,6 +508,8 @@ AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.o
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030017> "Section 14  of the German Heat Planning Act (WPG)")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)
+AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030017> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
+pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -504,6 +504,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (suitability assessment)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -504,6 +504,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (suitability assessment)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -518,6 +518,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncor
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "Dokumentation der verkürzten Wärmeplanung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning documentation"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "verkürzte Wärmeplanung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030018> "Section 14  of the German Heat Planning Act (WPG)")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -527,6 +527,7 @@ AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "s
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030018> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001808> <https://purl.org/mhpo/ontology/MHPO_00020019>))
 
 
 DisjointClasses(<https://purl.org/mhpo/ontology/MHPO_00020023> <https://purl.org/mhpo/ontology/MHPO_00020024> <https://purl.org/mhpo/ontology/MHPO_00020025>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -58,6 +58,7 @@ Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030012>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030013>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030014>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030016>))
+Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030017>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
@@ -500,6 +501,11 @@ AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/15")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> <https://purl.org/mhpo/ontology/MHPO_00020019>)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <https://purl.org/mhpo/ontology/MHPO_00020014>))
+
+# Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (suitability assessment)
+
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@de)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
 
 
 DisjointClasses(<https://purl.org/mhpo/ontology/MHPO_00020023> <https://purl.org/mhpo/ontology/MHPO_00020024> <https://purl.org/mhpo/ontology/MHPO_00020025>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -507,7 +507,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (initial suitability assessment)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents the initial research of grid bound heat supply, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents the initial research of grid bound heat supply, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid."@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability screeening"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030017> "Section 14  of the German Heat Planning Act (WPG)")

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -515,6 +515,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncor
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "verkürzte Wärmeplanung"@de)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -60,7 +60,13 @@ Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030014>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030016>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030017>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030018>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000476>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000853>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000965>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000974>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
+Declaration(ObjectProperty(<https://purl.org/mhpo/ontology/MHPO_00030019>))
+Declaration(ObjectProperty(<https://www.commoncoreontologies.org/ont00001808>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
 Declaration(AnnotationProperty(dcterms:creator))
@@ -105,6 +111,15 @@ AnnotationAssertion(rdfs:label rdfs:comment "comment")
 
 AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 
+
+############################
+#   Object Properties
+############################
+
+# Object Property: <https://purl.org/mhpo/ontology/MHPO_00030019> (has represented heat supply area)
+
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030019> "has represented heat supply area"@en)
+SubObjectPropertyOf(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://openenergyplatform.org/ontology/oeo/OEO_00010378>)
 
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -124,6 +124,8 @@ AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
 AnnotationAssertion(<https://www.commoncoreontologies.org/ont00001754> <https://purl.org/mhpo/ontology/MHPO_00030019> "Section 14  of the German Heat Planning Act (WPG)")
 SubObjectPropertyOf(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://openenergyplatform.org/ontology/oeo/OEO_00010378>)
+ObjectPropertyDomain(<https://purl.org/mhpo/ontology/MHPO_00030019> <http://purl.obolibrary.org/obo/IAO_0000030>)
+ObjectPropertyRange(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://purl.org/mhpo/ontology/MHPO_00020021>)
 
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -128,6 +128,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00020008>))
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00030001>))
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00030017>))
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00020003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <https://purl.org/mhpo/ontology/MHPO_00030018>))
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00020005> (aggregated inventory analysis)
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -509,6 +509,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030017> "A suitability assessment is a descriptive information content entity that documents the initial research of grid bound heat supply, based on available information and stakeholder consultation, whether one or more heat plan subareas are highly likely not suitable for supply by a district heating network or a hydrogen grid.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "Eignungsprüfung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability screeening"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000119> <https://purl.org/mhpo/ontology/MHPO_00030017> "Section 14  of the German Heat Planning Act (WPG)")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "initial suitability assessment"@en)
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030017> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -515,6 +515,8 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncor
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "Dokumentation der verkürzten Wärmeplanung"@de)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning documentation"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "verkürzte Wärmeplanung"@de)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030018> <https://www.commoncoreontologies.org/ont00000853>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -517,6 +517,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncor
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030018> (shortened heat planning)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030018> "A shortened heat planning is a descriptive information content entity that documents, in a municipal heat plan, that one or more heat plan subareas are represented as prospective decentralized heat supply areas based on a suitability assessment indicating that they are highly likely not suitable for supply by a district heating network or a hydrogen grid. Only potentials relevant for decentralized heat supply are considered for these subareas.")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "Dokumentation der verkürzten Wärmeplanung"@de)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "shortened heat planning documentation"@en)
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030018> "verkürzte Wärmeplanung"@de)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -118,7 +118,11 @@ AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 
 # Object Property: <https://purl.org/mhpo/ontology/MHPO_00030019> (has represented heat supply area)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030019> "An is-about-relation between an information content entity of a municipal heat plan and a heat supply area to indicate a heat supply area represented in the municipal heat plan."@en)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030019> "has represented heat supply area"@en)
+AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030019> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
+pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")
+AnnotationAssertion(<https://www.commoncoreontologies.org/ont00001754> <https://purl.org/mhpo/ontology/MHPO_00030019> "Section 14  of the German Heat Planning Act (WPG)")
 SubObjectPropertyOf(<https://purl.org/mhpo/ontology/MHPO_00030019> <https://openenergyplatform.org/ontology/oeo/OEO_00010378>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -116,9 +116,9 @@ AnnotationAssertion(rdfs:label owl:versionInfo "versionInfo")
 #   Object Properties
 ############################
 
-# Object Property: <https://purl.org/mhpo/ontology/MHPO_00030019> (has represented heat supply area)
+# Object Property: <https://purl.org/mhpo/ontology/MHPO_00030019> (represents heat supply area)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030019> "An is-about-relation between an information content entity of a municipal heat plan and a heat supply area to indicate a heat supply area represented in the municipal heat plan."@en)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030019> "An is-about-relation between a municipal heat plan and the heat supply area the heat municipal heat plan refers to."@en)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030019> "represents heat supply area"@en)
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030019> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/17
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/21")

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -504,7 +504,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030017> (suitability assessment)
 
-AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@de)
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030017> "suitability assessment"@en)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030017> <https://www.commoncoreontologies.org/ont00000853>)
 
 


### PR DESCRIPTION
## Summary of the discussion

Based on #17 

## Type of change (CHANGELOG.md)

### Added

- `suitability assessment`
- `shortened heat planning` 
- propterty `has represented heat supply area`

## Workflow checklist

### Automation

Part of # / Closes #

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/develop/CHANGELOG.md)
- [ ] 📙 Update the documentation
- [ ] 🐙 Assign a reviewer to the PR

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
