### PR TITLE
Add new class building stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- building stock, building count (#23)
 - municipal heat plan, aggregated inventory analysis, aggregated potential analysis, target scenario, implementation measure, implementation strategy (#9)
 - municipality area, heat supply area, area for decentralized heat supply, unallocated heat supply subarea, and respective roles (#15)
 - district heating area and subclasses, energy saving area, hydrogen grid area, area under suitability assessment, and respective roles (#15)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -59,6 +59,7 @@ Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030013>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030014>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030016>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030020>))
+Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030021>))
 Declaration(Class(<https://www.commoncoreontologies.org/ont00000476>))
 Declaration(Class(<https://www.commoncoreontologies.org/ont00000853>))
 Declaration(Class(<https://www.commoncoreontologies.org/ont00000965>))
@@ -513,6 +514,11 @@ AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030020> "b
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030020> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/23
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/26")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030020> <http://purl.obolibrary.org/obo/BFO_0000027>)
+
+# Class: <https://purl.org/mhpo/ontology/MHPO_00030021> (building count)
+
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030021> "building count"@en)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030021> <https://openenergyplatform.org/ontology/oeo/OEO_00000350>)
 
 
 DisjointClasses(<https://purl.org/mhpo/ontology/MHPO_00020023> <https://purl.org/mhpo/ontology/MHPO_00020024> <https://purl.org/mhpo/ontology/MHPO_00020025>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -518,7 +518,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030020> <http://purl.obolibrar
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030021> (building count)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030021> "A building count is a quantity value that measures the number of buildings in a building stock."@en)
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030021> "building stock size")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030021> "building stock size"@en)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030021> "building count"@en)
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030021> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/23
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/26")

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -518,6 +518,7 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030020> <http://purl.obolibrar
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030021> (building count)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030021> "A building count is a quantity value that measures the number of buildings in a building stock."@en)
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000118> <https://purl.org/mhpo/ontology/MHPO_00030021> "building stock size")
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030021> "building count"@en)
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030021> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/23
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/26")

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -523,6 +523,7 @@ AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030021> "b
 AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030021> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/23
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/26")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030021> <https://openenergyplatform.org/ontology/oeo/OEO_00000350>)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030021> ObjectSomeValuesFrom(<https://openenergyplatform.org/ontology/oeo/OEO_00020056> <https://purl.org/mhpo/ontology/MHPO_00030020>))
 
 
 DisjointClasses(<https://purl.org/mhpo/ontology/MHPO_00020023> <https://purl.org/mhpo/ontology/MHPO_00020024> <https://purl.org/mhpo/ontology/MHPO_00020025>)

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -517,7 +517,10 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030020> <http://purl.obolibrar
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030021> (building count)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030021> "A building count is a quantity value that measures the number of buildings in a building stock."@en)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030021> "building count"@en)
+AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030021> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/23
+pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/26")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030021> <https://openenergyplatform.org/ontology/oeo/OEO_00000350>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -508,7 +508,10 @@ SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<
 
 # Class: <https://purl.org/mhpo/ontology/MHPO_00030020> (building stock)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <https://purl.org/mhpo/ontology/MHPO_00030020> "A building stock is an object aggregate of buildings located in a spatial region."@en)
 AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030020> "building stock"@en)
+AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <https://purl.org/mhpo/ontology/MHPO_00030020> "issue: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/issues/23
+pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/26")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030020> <http://purl.obolibrary.org/obo/BFO_0000027>)
 
 

--- a/src/ontology/mhpo-edit.owl
+++ b/src/ontology/mhpo-edit.owl
@@ -58,6 +58,11 @@ Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030012>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030013>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030014>))
 Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030016>))
+Declaration(Class(<https://purl.org/mhpo/ontology/MHPO_00030020>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000476>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000853>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000965>))
+Declaration(Class(<https://www.commoncoreontologies.org/ont00000974>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
@@ -500,6 +505,11 @@ AnnotationAssertion(<https://openenergyplatform.org/ontology/oeo/OEO_00020426> <
 pull request: https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/pull/15")
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> <https://purl.org/mhpo/ontology/MHPO_00020019>)
 SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <https://purl.org/mhpo/ontology/MHPO_00020014>))
+
+# Class: <https://purl.org/mhpo/ontology/MHPO_00030020> (building stock)
+
+AnnotationAssertion(rdfs:label <https://purl.org/mhpo/ontology/MHPO_00030020> "building stock"@en)
+SubClassOf(<https://purl.org/mhpo/ontology/MHPO_00030020> <http://purl.obolibrary.org/obo/BFO_0000027>)
 
 
 DisjointClasses(<https://purl.org/mhpo/ontology/MHPO_00020023> <https://purl.org/mhpo/ontology/MHPO_00020024> <https://purl.org/mhpo/ontology/MHPO_00020025>)


### PR DESCRIPTION
## Summary of the discussion

Add new classes `building stock` and `building count` to cover building counts specified by sectors.
Relations and more necessary classes will be defined in subissue #24. 

## Type of change (CHANGELOG.md)

### Added

- Add a new class `building stock`
- Add a new class `building count`
- Add a new relation `refers to building stock`

## Workflow checklist

### Automation

Closes #23

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation
- [ ] 🐙 Assign a reviewer to the PR

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/municipal-heat-planning-ontology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
